### PR TITLE
feat(Event-Store): Add `Terminate` as a way of gracefully shutting down

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
       "tsx",
       "js"
     ],
+    "watchPathIgnorePatterns": [
+      "node_modules"
+    ],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/src/IStorageEngine.ts
+++ b/src/IStorageEngine.ts
@@ -54,6 +54,19 @@ interface IStorageEngine {
     startPosition: number,
     numberOfEvents: number
   ): Promise<EventStorage[]>
+
+  /**
+   * Much like being initialized, the event store needs to be terminated gracefully
+   * in the case of an expected shutdown, or during testing.
+   *
+   * There is no guarantee as to whether a particular engine requires this call,
+   * so I'll leave that up to the consumer to figure out from the engine-specific
+   * documentation.
+   *
+   * @returns {Promise<void>}
+   * @memberof IStorageEngine
+   */
+  terminate(): Promise<void>
 }
 
 export { IStorageEngine }

--- a/src/inMemory/InMemoryStorageEngine.ts
+++ b/src/inMemory/InMemoryStorageEngine.ts
@@ -41,6 +41,10 @@ class InMemoryStorageEngine implements IStorageEngine {
   public async initialise(): Promise<IStorageEngine> {
     return this
   }
+
+  public async terminate(): Promise<void> {
+    this.streams.clear()
+  }
 }
 
 export { InMemoryStorageEngine }

--- a/test/EventStore.Appending.test.ts
+++ b/test/EventStore.Appending.test.ts
@@ -140,5 +140,10 @@ describe('Given a set of engines to test against', () => {
         })
       })
     })
+    describe('When terminating the event store', () => {
+      it(`It should just terminate without any bells and whistles (this is an in memory store we're talking about`, async () => {
+        await expect(engine.terminate()).resolves.not.toThrowError()
+      })
+    })
   })
 })


### PR DESCRIPTION
As part of working on the PostgreSQL storage engine, I realised that for most of the engine
implementations, I would need a way to signify that the application itself is shutting down, and a
graceful shutdown is required. This could entail closing connections, draining pools, etc. Basically
perform some good-citizen duties.