### PR TITLE
docs(readme): Remove dependency checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ![npm (scoped)](https://img.shields.io/npm/v/@make-stuff-work/event-sauced.svg)
 [![Coverage Status](https://coveralls.io/repos/github/YannickMeeus/event-sauced-ts/badge.svg?branch=master)](https://coveralls.io/github/YannickMeeus/event-sauced-ts?branch=master)
-[![Dev Dependencies](https://david-dm.org/YannickMeeus/event-sauced-ts/dev-status.svg)](https://david-dm.org/YannickMeeus/event-sauced-ts?type=dev)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 


### PR DESCRIPTION
It's not quite there at the moment, quite a bit of downtime. Let's see if it comes back but for now, removing the badge.