### PR TITLE
feat(eventstore): support deletion of streams as a first-class operation

### DIFF
--- a/src/EventStore.ts
+++ b/src/EventStore.ts
@@ -71,6 +71,11 @@ class EventStore {
     Guard.againstNullOrEmpty('streamId', streamId)
     return this.engine.readStreamForwards(streamId, startPosition, numberOfEvents)
   }
+
+  public async deleteStream(streamId: string): Promise<void> {
+    Guard.againstNullOrEmpty('streamId', streamId)
+    return this.engine.deleteStream(streamId)
+  }
 }
 
 export { EventStore }

--- a/src/IStorageEngine.ts
+++ b/src/IStorageEngine.ts
@@ -5,7 +5,7 @@ interface IStorageEngine {
    * Some storage engines require initialization. This can include:
    *  - Creating a new table/document collection to hold the streams
    *  - Adding constraints to aid in concurrency checks
-   *  - Adding indeces to facilitate efficient querying
+   *  - Adding indexes to facilitate efficient querying
    *  - Adding unique key constrains to ensure data integrity
    *  - Setting throughput requirements accordingly
    *  - Waiting for initialization is complete and the collection is writeable prior
@@ -56,12 +56,26 @@ interface IStorageEngine {
   ): Promise<EventStorage[]>
 
   /**
+   * Completely deletes an entire stream. This is a destructive operation, so please ensure
+   * this is what you want to achieve.
+   *
+   * If the stream is non-existent, the operation should be idem-potent and return
+   * a success. It should only throw in case deletion is impossible due to downstream failures.
+   *
+   * @param {string} streamIdT his is the core identifier for a single stream.
+   * It can be the natural unique key for an event type, such as a 'user id'.
+   * @returns {Promise<void>}
+   * @memberof IStorageEngine
+   */
+  deleteStream(streamId: string): Promise<void>
+
+  /**
    * Much like being initialized, the event store needs to be terminated gracefully
    * in the case of an expected shutdown, or during testing.
    *
    * There is no guarantee as to whether a particular engine requires this call,
    * so I'll leave that up to the consumer to figure out from the engine-specific
-   * documentation.
+   * documentation. If in doubt, terminate.
    *
    * @returns {Promise<void>}
    * @memberof IStorageEngine

--- a/src/inMemory/InMemoryStorageEngine.ts
+++ b/src/inMemory/InMemoryStorageEngine.ts
@@ -39,6 +39,14 @@ class InMemoryStorageEngine implements IStorageEngine {
     return this.streams.get(streamId)!.slice(index, startPosition + numberOfEvents)
   }
 
+  async deleteStream(streamId: string): Promise<void> {
+    if (!this.streams.get(streamId)) {
+      return
+    }
+
+    this.streams.delete(streamId)
+  }
+
   public async initialise(): Promise<IStorageEngine> {
     return this
   }

--- a/test/EventStore.Deleting.test.ts
+++ b/test/EventStore.Deleting.test.ts
@@ -1,0 +1,58 @@
+import { InMemoryStorageEngine } from '../src/inMemory/InMemoryStorageEngine'
+import { IStorageEngine } from '../src/IStorageEngine'
+import * as uuid from 'uuid'
+import { EventStore } from '../src/EventStore'
+import { EventData } from '../src/EventData'
+import { OrderCreated } from './Events/OrderCreated'
+import { OrderDispatched } from './Events/OrderDispatched'
+
+describe('Given a set of engines to test against', () => {
+  const engineFactories: (() => IStorageEngine)[] = [() => new InMemoryStorageEngine()]
+  const newGuid = () => uuid.v4()
+  engineFactories.forEach((getEngine) => {
+    const engine = getEngine()
+
+    const getStore = async () => {
+      await engine.initialise()
+      return new EventStore(engine)
+    }
+    describe('When deleting any stream', () => {
+      describe('And the stream id is dodgy', () => {
+        const invalidStreamIds = [null, undefined, '', ' ']
+        invalidStreamIds.forEach((invalidStreamId) => {
+          it(`It should throw an error for stream id: '${invalidStreamId}'`, async () => {
+            const sut = await getStore()
+            await expect(sut.deleteStream(invalidStreamId as string)).rejects.toThrow(
+              'streamId can not be null, empty string or contain only whitespace'
+            )
+          })
+        })
+      })
+    })
+    describe('When deleting an empty stream', () => {
+      it('It should successfully complete', async () => {
+        const streamId = newGuid()
+        const sut = await getStore()
+        await expect(sut.deleteStream(streamId)).resolves.not.toThrow()
+      })
+    })
+    describe('When deleting an existing stream', () => {
+      it('It should delete all events from the stream all events', async () => {
+        const streamId = newGuid()
+        const sut = await getStore()
+        const firstEvent = new EventData(newGuid(), new OrderCreated(streamId))
+        const secondEvent = new EventData(newGuid(), new OrderDispatched(streamId))
+
+        await sut.AppendToStream(streamId, 0, firstEvent)
+        await sut.AppendToStream(streamId, 1, secondEvent)
+
+        const stream = await sut.readStreamForwards(streamId)
+
+        expect(stream).toHaveLength(2)
+        await sut.deleteStream(streamId)
+        const noEvents = await sut.readStreamForwards(streamId)
+        expect(noEvents).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
While it's not considered best practice, having a supported way to actually delete an entire stream
should still be possible without having to reach into storage-specific bits of the application. I'm
not saying you should do this, but I am saying it's doable *if you know what the reprecussions are*.
Your event store is the source of truth, or should be, of your system. Nuking streams is destructive
and unrecoverable unless you can reinsert those items back into their rightful position. Just
appending will result in a new stream, with a new cursor, not ideal as it'll screw up your
projections.

BREAKING CHANGE: Adding new member to EventStore Engine Interface causes downstream plugin-libraries
to break.